### PR TITLE
[Issue #14] Prevent _quillObserver from updating awareness states on silent Quill events

### DIFF
--- a/src/y-quill.js
+++ b/src/y-quill.js
@@ -121,7 +121,7 @@ export class QuillBinding {
         }
       }
       // always check selection
-      if (awareness && quillCursors) {
+      if (awareness && quillCursors && origin !== 'silent') {
         const sel = quill.getSelection()
         const aw = /** @type {any} */ (awareness.getLocalState())
         if (sel === null) {


### PR DESCRIPTION
See [the related GitHub issue](https://github.com/yjs/y-quill/issues/14) for a detailed explanation of the issue.